### PR TITLE
Fix permission error when syncing with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,12 +43,12 @@ ENV PORT=3000
 WORKDIR /app
 COPY --from=build /app ./
 
-# /books is where books are read from, /library is the tree the sync tool
-# builds, /data holds the published library and everything the app writes to
-# it. Created and owned here so a named volume mounted at /data inherits an
-# ownership the app can actually write to.
-RUN mkdir -p /books /library /data/library \
-  && chown -R node:node /books /library /data
+# /books is where books are read from, /data holds the build output, the
+# published library, and everything the app writes to. /data is created before
+# any mounts so a named volume mounted at /data inherits ownership the app
+# can actually write to.
+RUN mkdir -p /books /data/library-build /data/library \
+  && chown -R node:node /books /data
 
 USER node
 EXPOSE 3000

--- a/docker/bookshelf.config.json
+++ b/docker/bookshelf.config.json
@@ -1,6 +1,6 @@
 {
   "input": "/books",
-  "output": "/library",
+  "output": "/data/library-build",
   "coverHeight": 240,
   "storage": {
     "provider": "fs",

--- a/packages/provider-fs/src/node.ts
+++ b/packages/provider-fs/src/node.ts
@@ -264,9 +264,11 @@ async function walk(root: string): Promise<string[]> {
  * its folder behind for good.
  */
 async function pruneEmpty(root: string, from: string): Promise<void> {
+  const sep = path.sep;
+  const rootWithSep = root + sep;
   let directory = path.dirname(from);
 
-  while (directory.startsWith(root) && directory !== root) {
+  while (directory !== root && directory.startsWith(rootWithSep)) {
     try {
       await rmdir(directory);
     } catch {


### PR DESCRIPTION
Fixes #6

Fixed the permission error when running docker compose run --rm sync --create.

Root Cause: The Dockerfile was creating /library at the root level, but the node user couldn't remove it during rebuilds since / is owned by root and not writable by regular users. When the sync tool tried to clean up the old build output with rm('/library', { recursive: true }), it failed with EACCES: permission denied.

## What this changes

1. Dockerfile — Moved build output directory from /library to /data/library-build so all user-writable files stay under /data
2. docker/bookshelf.config.json — Updated output path to /data/library-build
3. packages/provider-fs/src/node.ts — Improved pruneEmpty's path checking to use separator-aware startsWith for safer directory traversal

## How you verified it

<!--
There are no tests yet, so this is the part that carries the weight. What did
you actually run? The filesystem quickstart in the README exercises publishing,
the shelf, the reader and reading positions in about a minute.
-->

- [X] `docker compose run --rm sync --create`
- [X] `npm run lint`
- [X] `npm run check-types`
- [X] Ran it, and said above what I ran
